### PR TITLE
fix(netease): detect plain vs synced lyrics and respect config (#14)

### DIFF
--- a/src/format/lrc.rs
+++ b/src/format/lrc.rs
@@ -111,6 +111,12 @@ pub fn is_instrumental(lyrics: &str) -> bool {
     INSTRUMENTAL_MARKERS.iter().any(|m| lower.contains(m))
 }
 
+pub fn is_synced(lyrics: &str) -> bool {
+    lyrics
+        .lines()
+        .any(|line| matches!(parse_line(line), Some((Some(_), _))))
+}
+
 fn parse_line(line: &str) -> Option<(Option<f64>, &str)> {
     let trimmed = line.trim_start_matches('\u{feff}').trim();
 
@@ -139,6 +145,7 @@ fn parse_line(line: &str) -> Option<(Option<f64>, &str)> {
 #[cfg(test)]
 mod tests {
     use super::is_instrumental;
+    use super::is_synced;
     use super::sanitize;
 
     mod sanitize_tests {
@@ -362,6 +369,55 @@ mod tests {
             let input = concat!("[offset:0]\n", "[00:01.00]instrumental\n");
 
             assert!(is_instrumental(input));
+        }
+    }
+
+    mod is_synced_tests {
+        use super::is_synced;
+
+        #[test]
+        fn test_real_synced_lrc_is_synced() {
+            let input = concat!("[00:01.00]Hello\n", "[00:05.00]World\n");
+
+            assert!(is_synced(input));
+        }
+
+        #[test]
+        fn test_metadata_tags_before_timed_line_is_synced() {
+            let input = concat!(
+                "[ar:Artist]\n",
+                "[al:Album]\n",
+                "[ti:Title]\n",
+                "[00:01.00]Hello\n"
+            );
+
+            assert!(is_synced(input));
+        }
+
+        #[test]
+        fn test_plain_multiline_text_is_not_synced() {
+            let input = "Hello\nWorld\n";
+
+            assert!(!is_synced(input));
+        }
+
+        #[test]
+        fn test_bracketed_non_time_label_is_not_synced() {
+            let input = "[Verse 1]\nHello\nWorld\n";
+
+            assert!(!is_synced(input));
+        }
+
+        #[test]
+        fn test_empty_input_is_not_synced() {
+            assert!(!is_synced(""));
+        }
+
+        #[test]
+        fn test_bom_is_handled() {
+            let input = "\u{feff}[00:01.00]Hello";
+
+            assert!(is_synced(input));
         }
     }
 }

--- a/src/providers/netease.rs
+++ b/src/providers/netease.rs
@@ -57,7 +57,7 @@ impl NetEase {
 
 impl LyricsProvider for NetEase {
     fn fetch_lyrics(&self, track: &TrackInfo, cfg: &PluginConfig) -> Result<Option<Lyrics>, Error> {
-        if !cfg.wants_synced() && !cfg.wants_plain() {
+        if !cfg.wants_synced() {
             return Ok(None);
         }
 

--- a/src/providers/netease.rs
+++ b/src/providers/netease.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::PluginConfig,
+    format::lrc,
     providers::{FIREFOX_USER_AGENT, LyricsProvider},
     types::Lyrics,
 };
@@ -56,7 +57,7 @@ impl NetEase {
 
 impl LyricsProvider for NetEase {
     fn fetch_lyrics(&self, track: &TrackInfo, cfg: &PluginConfig) -> Result<Option<Lyrics>, Error> {
-        if !cfg.wants_synced() {
+        if !cfg.wants_synced() && !cfg.wants_plain() {
             return Ok(None);
         }
 
@@ -75,7 +76,7 @@ impl LyricsProvider for NetEase {
             None => return Ok(None),
         };
 
-        fetch_lrc(song.id)
+        fetch_lrc(song.id, cfg)
     }
 }
 
@@ -103,7 +104,7 @@ fn search_song(query: &str, target_ms: u64) -> Result<Option<Song>, Error> {
     }))
 }
 
-fn fetch_lrc(song_id: u64) -> Result<Option<Lyrics>, Error> {
+fn fetch_lrc(song_id: u64, cfg: &PluginConfig) -> Result<Option<Lyrics>, Error> {
     let qs = serde_urlencoded::to_string([
         ("id", song_id.to_string()),
         ("kv", "-1".to_string()),
@@ -124,15 +125,26 @@ fn fetch_lrc(song_id: u64) -> Result<Option<Lyrics>, Error> {
     let parsed: LyricsResponse = serde_json::from_slice(&response.body)
         .map_err(|e| Error::new(format!("netease: failed to parse lyrics response: {e}")))?;
 
-    Ok(if parsed.pure_music {
-        Some(Lyrics::Instrumental)
+    if parsed.pure_music {
+        return Ok(Some(Lyrics::Instrumental));
+    }
+
+    let text = match parsed.lrc.and_then(|l| l.lyric) {
+        Some(text) if !text.trim().is_empty() => text,
+        _ => return Ok(None),
+    };
+
+    if lrc::is_synced(&text) {
+        if !cfg.wants_synced() {
+            return Ok(None);
+        }
+        Ok(Some(Lyrics::Synced(text)))
     } else {
-        parsed
-            .lrc
-            .and_then(|l| l.lyric)
-            .filter(|s| !s.trim().is_empty())
-            .map(Lyrics::Synced)
-    })
+        if !cfg.wants_plain() {
+            return Ok(None);
+        }
+        Ok(Some(Lyrics::Plain(text)))
+    }
 }
 
 fn send_request(url: &str) -> Result<HTTPResponse, Error> {


### PR DESCRIPTION
Fixes #14.

NetEase can return plain (un-timestamped) lyrics in the `lrc.lyric` field, but
`fetch_lrc` wrapped that text unconditionally as `Lyrics::Synced`. As a result
plain text was treated as synced everywhere downstream and got returned even when
plain lyrics were disabled, since nothing re-checked the real type.

Changes:
- Add `is_synced()` in `format/lrc.rs` (reuses `parse_line`; true if any line
  carries a timestamp tag).
- In `netease.rs`, classify the fetched text as synced/plain and only return it
  when that type is enabled in the config; widen the early guard so the provider
  also runs when only plain is wanted.
- Unit tests for `is_synced`, modeled on the existing `is_instrumental` tests.