### PR TITLE
Add lrcmux provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ At this time, the following providers are available. Please report any issues yo
 | ----------- | -------------------- | :----------: | :----------: | ------------------------------- |
 | LRCLIB      | plain,lrc,lyricsfile |      ✗       |      ✗       | Supports custom base URL        |
 | lyrics.ovh  | plain                |      ✗       |      ✗       | Supports custom base URL        |
+| lrcmux      | plain,lrc,elrc       |      ✗       |      ✗       | Supports custom base URL        |
 | KuGou       | lrc,elrc             |      ✗       |      ✗       |                                 |
 | NetEase     | lrc,elrc             |      ✗       |      ✗       |                                 |
 | QQ Music    | lrc,elrc             |      ✗       |      ✗       |                                 |

--- a/manifest.json
+++ b/manifest.json
@@ -70,6 +70,7 @@
                 "oneOf": [
                   { "const": "lrclib", "title": "LRCLIB" },
                   { "const": "lyrics.ovh", "title": "lyrics.ovh" },
+                  { "const": "lrcmux", "title": "lrcmux" },
                   { "const": "kugou", "title": "KuGou" },
                   { "const": "netease", "title": "NetEase" },
                   { "const": "qqmusic", "title": "QQ Music" },
@@ -336,7 +337,7 @@
                         "condition": {
                           "scope": "#/properties/provider",
                           "schema": {
-                            "enum": ["lrclib", "lyrics.ovh"]
+                            "enum": ["lrclib", "lyrics.ovh", "lrcmux"]
                           }
                         }
                       }

--- a/src/providers/lrcmux.rs
+++ b/src/providers/lrcmux.rs
@@ -1,0 +1,229 @@
+use crate::{
+    config::{PluginConfig, ProviderParams},
+    providers::{LyricsProvider, USER_AGENT},
+    types::{Lyrics, LyricsKind},
+};
+use nd_pdk::{
+    host::http::{self, HTTPRequest, HTTPResponse},
+    lyrics::{Error, TrackInfo},
+};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+const DEFAULT_BASE_URL: &str = "https://api.lrcmux.dev";
+
+#[derive(Deserialize)]
+struct JsonResponse {
+    meta: JsonMeta,
+    lines: Option<Vec<Line>>,
+}
+
+#[derive(Deserialize)]
+struct JsonMeta {
+    level: SyncLevel,
+}
+
+#[derive(Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum SyncLevel {
+    Word,
+    Line,
+    None,
+}
+
+#[derive(Deserialize)]
+struct Line {
+    text: String,
+    start: Option<i64>,
+    end: Option<i64>,
+    words: Option<Vec<Word>>,
+}
+
+#[derive(Deserialize)]
+struct Word {
+    text: String,
+    start: i64,
+}
+
+pub struct LrcMux {
+    base_url: String,
+}
+
+impl LrcMux {
+    pub fn create(params: &ProviderParams) -> Box<dyn LyricsProvider> {
+        Box::new(Self {
+            base_url: params
+                .get("baseUrl")
+                .unwrap_or(DEFAULT_BASE_URL)
+                .to_string(),
+        })
+    }
+}
+
+impl LyricsProvider for LrcMux {
+    fn supported_kinds(&self) -> &'static [LyricsKind] {
+        &[LyricsKind::Elrc, LyricsKind::Lrc, LyricsKind::Plain]
+    }
+
+    fn log_params(&self) -> Vec<(&'static str, String)> {
+        vec![("baseUrl", self.base_url.clone())]
+    }
+
+    fn fetch_lyrics(&self, track: &TrackInfo, cfg: &PluginConfig) -> Result<Option<Lyrics>, Error> {
+        let first_artist = track
+            .artists
+            .first()
+            .ok_or_else(|| Error::new("missing artist"))?
+            .name
+            .as_str();
+
+        let duration = track.duration.round() as i64;
+
+        let qs = serde_urlencoded::to_string([
+            ("artist", first_artist),
+            ("title", track.title.as_str()),
+            ("album", track.album.as_str()),
+            ("duration", &duration.to_string()),
+        ])
+        .map_err(|e| Error::new(format!("lrcmux: failed to encode query: {e}")))?;
+
+        let response = send_request(&format!("{}/get?{qs}", self.base_url))?;
+
+        match response.status_code {
+            200 => {
+                let parsed: JsonResponse = serde_json::from_slice(&response.body)
+                    .map_err(|e| Error::new(format!("lrcmux: failed to parse response: {e}")))?;
+
+                let level = parsed.meta.level;
+                let lines = parsed.lines.unwrap_or_default();
+
+                for &kind in cfg.resolve_order() {
+                    match kind {
+                        LyricsKind::Elrc => {
+                            if level != SyncLevel::Word {
+                                continue;
+                            }
+                            return Ok(Some(Lyrics::Elrc(build_elrc(&lines))));
+                        }
+                        LyricsKind::Lrc => {
+                            if level == SyncLevel::None {
+                                continue;
+                            }
+                            return Ok(Some(Lyrics::Lrc(build_lrc(&lines))));
+                        }
+                        LyricsKind::Plain => {
+                            let text = lines
+                                .iter()
+                                .map(|l| l.text.as_str())
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            return Ok(Some(Lyrics::Plain(text)));
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(None)
+            }
+            404 => Ok(None),
+            code => Err(Error::new(format!(
+                "lrcmux: returned unexpected status {code}"
+            ))),
+        }
+    }
+}
+
+fn build_elrc(lines: &[Line]) -> String {
+    lines
+        .iter()
+        .map(|l| {
+            let mut buf = format!("[{}]", ms_to_ts(l.start.unwrap()));
+            for w in l.words.as_deref().unwrap() {
+                buf.push_str(&format!("<{}>{}", ms_to_ts(w.start), w.text));
+            }
+            buf.push_str(&format!("<{}>", ms_to_ts(l.end.unwrap())));
+            buf
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_lrc(lines: &[Line]) -> String {
+    lines
+        .iter()
+        .map(|l| format!("[{}] {}", ms_to_ts(l.start.unwrap()), l.text))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn ms_to_ts(ms: i64) -> String {
+    let ms = ms.max(0);
+    let total_cs = ms / 10;
+    let cs = total_cs % 100;
+    let total_secs = total_cs / 100;
+    let secs = total_secs % 60;
+    let mins = total_secs / 60;
+    format!("{mins:02}:{secs:02}.{cs:02}")
+}
+
+fn send_request(url: &str) -> Result<HTTPResponse, Error> {
+    let mut headers = HashMap::new();
+    headers.insert("User-Agent".into(), USER_AGENT.into());
+
+    http::send(HTTPRequest {
+        url: url.into(),
+        method: "GET".into(),
+        headers,
+        no_follow_redirects: false,
+        body: Vec::new(),
+        timeout_ms: 15_000,
+    })
+    .map_err(|e| Error::new(format!("lrcmux: HTTP request failed: {e}")))?
+    .ok_or_else(|| Error::new("lrcmux: received empty response"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_elrc_output() {
+        let lines = vec![Line {
+            text: "hello world".into(),
+            start: Some(1000),
+            end: Some(3000),
+            words: Some(vec![
+                Word {
+                    text: "hello".into(),
+                    start: 1000,
+                },
+                Word {
+                    text: "world".into(),
+                    start: 2000,
+                },
+            ]),
+        }];
+        assert_eq!(
+            build_elrc(&lines),
+            "[00:01.00]<00:01.00>hello<00:02.00>world<00:03.00>"
+        );
+    }
+
+    #[test]
+    fn test_lrc_output() {
+        let lines = vec![
+            Line {
+                text: "first".into(),
+                start: Some(1000),
+                end: None,
+                words: None,
+            },
+            Line {
+                text: "second".into(),
+                start: Some(2500),
+                end: None,
+                words: None,
+            },
+        ];
+        assert_eq!(build_lrc(&lines), "[00:01.00] first\n[00:02.50] second");
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::PluginConfig,
     providers::{
-        applemusic::AppleMusic, kugou::Kugou, lrclib::Lrclib, lyricsovh::LyricsOvh,
+        applemusic::AppleMusic, kugou::Kugou, lrclib::Lrclib, lrcmux::LrcMux, lyricsovh::LyricsOvh,
         netease::NetEase, qqmusic::QQMusic, stixoi::Stixoi,
     },
     registry::ProviderRegistry,
@@ -12,6 +12,7 @@ use nd_pdk::lyrics::{Error, TrackInfo};
 mod applemusic;
 mod kugou;
 mod lrclib;
+mod lrcmux;
 mod lyricsovh;
 mod netease;
 mod qqmusic;
@@ -29,6 +30,7 @@ const BROWSER_USER_AGENT: &str =
 pub fn register_providers(registry: &mut ProviderRegistry) {
     registry.register("lrclib", Lrclib::create);
     registry.register("lyrics.ovh", LyricsOvh::create);
+    registry.register("lrcmux", LrcMux::create);
     registry.register("kugou", Kugou::create);
     registry.register("netease", NetEase::create);
     registry.register("qqmusic", QQMusic::create);


### PR DESCRIPTION
(To start off: I'm the maintainer of lrcmux (and the hosted instance), I thought it might be better to mention that beforehand)

This PR adds [lrcmux](https://github.com/f1nniboy/lrcmux), which is an API that queries several lyrics backends (Musixmatch, Kugou, YouTube Music, etc.) and returns the best match, line-synced if available. I thought it'd be a great fit for this plugin, as LRCLIB can be quite lacking sometimes for more niche tracks, and lyrics.ovh only gives you plain-text lyrics. If users don't trust the hosted instance, they can freely run an instance themselves and set the base URL via the usual pattern.

Keep in mind that this is still a relatively young project, so I'd understand if you want to hold off, though, I would be happy to maintain the provider here if any issues come up or the API changes.