### PR TITLE
E/LRC improvements

### DIFF
--- a/src/format/elrc.rs
+++ b/src/format/elrc.rs
@@ -1,0 +1,192 @@
+use crate::format::lrc::format_timestamp;
+
+const AUDIBLE_PAUSE_MS: i64 = 150;
+const IMPLAUSIBLE_WORD_MS: i64 = 40;
+
+pub struct Word {
+    pub text: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+}
+
+impl Word {
+    fn new(text: impl Into<String>, start_ms: i64, end_ms: i64) -> Self {
+        Self {
+            text: text.into(),
+            start_ms,
+            end_ms,
+        }
+    }
+
+    fn duration(&self) -> i64 {
+        self.end_ms - self.start_ms
+    }
+
+    fn is_separator(&self) -> bool {
+        self.text.trim().is_empty()
+    }
+}
+
+fn holds_pause(word_ms: i64, gap_ms: i64) -> bool {
+    gap_ms >= AUDIBLE_PAUSE_MS && word_ms >= IMPLAUSIBLE_WORD_MS
+}
+
+pub fn render_line(line_start_ms: i64, words: &[Word]) -> Option<String> {
+    let tokens = split_pauses(&fold_separators(words));
+    let end = tokens.last()?.end_ms;
+
+    let mut buf = format!("[{}]", format_timestamp(line_start_ms));
+    for token in &tokens {
+        buf.push_str(&format!(
+            "<{}>{}",
+            format_timestamp(token.start_ms),
+            token.text
+        ));
+    }
+    buf.push_str(&format!("<{}>", format_timestamp(end)));
+    Some(buf)
+}
+
+/// Folds whitespace-only tokens into the word before them unless they are
+/// holding a real pause.
+fn fold_separators(words: &[Word]) -> Vec<Word> {
+    let mut out: Vec<Word> = Vec::with_capacity(words.len());
+    for word in words {
+        let fold = word.is_separator()
+            && out
+                .last()
+                .is_some_and(|prev| !holds_pause(prev.duration(), word.duration()));
+
+        if fold && let Some(prev) = out.last_mut() {
+            prev.text.push_str(&word.text);
+            prev.end_ms = word.end_ms;
+            continue;
+        }
+        out.push(Word::new(word.text.clone(), word.start_ms, word.end_ms));
+    }
+    out
+}
+
+/// Splits a word's trailing whitespace onto the pause that follows it.
+fn split_pauses(words: &[Word]) -> Vec<Word> {
+    let mut out: Vec<Word> = Vec::with_capacity(words.len());
+    for (i, word) in words.iter().enumerate() {
+        let gap = words.get(i + 1).map(|next| next.start_ms - word.end_ms);
+        let spoken = word.text.trim_end();
+
+        if let Some(next_start) = words.get(i + 1).map(|next| next.start_ms)
+            && holds_pause(word.duration(), gap.unwrap_or(0))
+            && !spoken.is_empty()
+            && spoken.len() < word.text.len()
+        {
+            out.push(Word::new(spoken, word.start_ms, word.end_ms));
+            out.push(Word::new(
+                &word.text[spoken.len()..],
+                word.end_ms,
+                next_start,
+            ));
+            continue;
+        }
+        out.push(Word::new(word.text.clone(), word.start_ms, word.end_ms));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn word(text: &str, start_ms: i64, end_ms: i64) -> Word {
+        Word::new(text, start_ms, end_ms)
+    }
+
+    #[test]
+    fn test_render_line_closes_on_the_last_word() {
+        let words = vec![word("hello ", 1000, 2000), word("world", 2000, 3000)];
+        assert_eq!(
+            render_line(1000, &words).unwrap(),
+            "[00:01.00]<00:01.00>hello <00:02.00>world<00:03.00>"
+        );
+    }
+
+    #[test]
+    fn test_render_line_is_none_without_words() {
+        assert!(render_line(1000, &[]).is_none());
+    }
+
+    #[test]
+    fn test_pause_moves_onto_the_trailing_space() {
+        let words = vec![
+            word("guy ", 129_364, 129_828),
+            word("duh", 134_956, 135_316),
+        ];
+        assert_eq!(
+            render_line(129_364, &words).unwrap(),
+            "[02:09.36]<02:09.36>guy<02:09.83> <02:14.96>duh<02:15.32>"
+        );
+    }
+
+    #[test]
+    fn test_short_gaps_stay_with_the_word() {
+        let words = vec![word("guy ", 1000, 1400), word("duh", 1500, 1800)];
+        assert_eq!(
+            render_line(1000, &words).unwrap(),
+            "[00:01.00]<00:01.00>guy <00:01.50>duh<00:01.80>"
+        );
+    }
+
+    #[test]
+    fn test_gap_after_an_implausibly_short_word_is_reclaimed() {
+        let words = vec![word("guy ", 1000, 1020), word("duh", 1800, 2000)];
+        assert_eq!(
+            render_line(1000, &words).unwrap(),
+            "[00:01.00]<00:01.00>guy <00:01.80>duh<00:02.00>"
+        );
+    }
+
+    #[test]
+    fn test_gap_without_trailing_whitespace_is_left_alone() {
+        let words = vec![word("難", 1000, 1400), word("忘", 2000, 2400)];
+        assert_eq!(
+            render_line(1000, &words).unwrap(),
+            "[00:01.00]<00:01.00>難<00:02.00>忘<00:02.40>"
+        );
+    }
+
+    #[test]
+    fn test_mistimed_separators_are_folded_into_their_word() {
+        let words = vec![
+            word("Looks", 42_350, 42_362),
+            word(" ", 42_362, 42_726),
+            word("like", 42_726, 42_746),
+            word(" ", 42_746, 42_969),
+            word("blue", 42_969, 42_983),
+        ];
+        assert_eq!(
+            render_line(42_350, &words).unwrap(),
+            "[00:42.35]<00:42.35>Looks <00:42.73>like <00:42.97>blue<00:42.98>"
+        );
+    }
+
+    #[test]
+    fn test_well_timed_separators_keep_their_own_segment() {
+        let words = vec![
+            word("here", 20_490, 20_870),
+            word(" ", 20_870, 21_020),
+            word("before", 21_020, 21_845),
+        ];
+        assert_eq!(
+            render_line(20_490, &words).unwrap(),
+            "[00:20.49]<00:20.49>here<00:20.87> <00:21.02>before<00:21.85>"
+        );
+    }
+
+    #[test]
+    fn test_a_leading_separator_has_no_word_to_fold_into() {
+        let words = vec![word(" ", 1000, 1100), word("hi", 1100, 2000)];
+        assert_eq!(
+            render_line(1000, &words).unwrap(),
+            "[00:01.00]<00:01.00> <00:01.10>hi<00:02.00>"
+        );
+    }
+}

--- a/src/format/lrc.rs
+++ b/src/format/lrc.rs
@@ -118,8 +118,13 @@ pub fn format_timestamp(ms: i64) -> String {
     let hundredths = cs % 100;
     let total_secs = cs / 100;
     let secs = total_secs % 60;
-    let mins = total_secs / 60;
-    format!("{mins:02}:{secs:02}.{hundredths:02}")
+    let total_mins = total_secs / 60;
+
+    if total_mins < 100 {
+        return format!("{total_mins:02}:{secs:02}.{hundredths:02}");
+    }
+    let (hours, mins) = (total_mins / 60, total_mins % 60);
+    format!("{hours:02}:{mins:02}:{secs:02}.{hundredths:02}")
 }
 
 pub(crate) fn is_blank_timed_line(line: &str) -> bool {
@@ -227,20 +232,31 @@ fn parse_line(line: &str) -> Option<(Option<f64>, &str)> {
     let content = &rest[..bracket_end];
     let text = &rest[bracket_end + 1..];
 
-    let time_tag_secs = content.split_once(':').and_then(|(left, right)| {
-        if left.chars().all(|c| c.is_ascii_digit())
-            && right.contains('.')
-            && right.chars().all(|c| c.is_ascii_digit() || c == '.')
-        {
-            let mins = left.parse::<f64>().ok()?;
-            let secs = right.parse::<f64>().ok()?;
-            Some(mins * 60.0 + secs)
-        } else {
-            None
-        }
-    });
+    Some((parse_time_tag(content), text))
+}
 
-    Some((time_tag_secs, text))
+fn parse_time_tag(content: &str) -> Option<f64> {
+    let mut fields = content.split(':');
+    let (first, second, third) = (fields.next()?, fields.next()?, fields.next());
+    if fields.next().is_some() {
+        return None;
+    }
+
+    let (hours, mins, secs) = match third {
+        Some(secs) => (first, second, secs),
+        None => ("0", first, second),
+    };
+
+    let whole = |f: &str| !f.is_empty() && f.chars().all(|c| c.is_ascii_digit());
+    if !whole(hours) || !whole(mins) {
+        return None;
+    }
+    if !secs.contains('.') || !secs.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return None;
+    }
+
+    let secs = secs.parse::<f64>().ok()?;
+    Some((hours.parse::<f64>().ok()? * 60.0 + mins.parse::<f64>().ok()?) * 60.0 + secs)
 }
 
 #[cfg(test)]
@@ -257,6 +273,23 @@ mod tests {
         assert_eq!(format_timestamp(736), "00:00.74");
         assert_eq!(format_timestamp(65_000), "01:05.00");
         assert_eq!(format_timestamp(-5), "00:00.00");
+    }
+
+    #[test]
+    fn test_sanitize_keeps_hour_form_lines() {
+        let lrc = "[01:40:05.00]<01:40:05.00>past <01:40:06.00>the hour<01:40:07.00>";
+        assert_eq!(sanitize(lrc), lrc);
+        assert!(is_synced(lrc));
+    }
+
+    #[test]
+    fn test_format_timestamp_rolls_into_hours_past_99_minutes() {
+        assert_eq!(format_timestamp(99 * 60_000 + 59_990), "99:59.99");
+        assert_eq!(format_timestamp(100 * 60_000), "01:40:00.00");
+        assert_eq!(
+            format_timestamp(3 * 3_600_000 + 25 * 60_000 + 7_120),
+            "03:25:07.12"
+        );
     }
 
     mod strip_word_tags_tests {

--- a/src/format/lrc.rs
+++ b/src/format/lrc.rs
@@ -3,6 +3,9 @@ use std::borrow::Cow;
 const KEEP_TAGS: &[&str] = &["offset"];
 
 const CREDIT_PREFIXES: &[&str] = &[
+    "Artist",
+    "Album",
+    "Title",
     "Lyrics by",
     "Composed by",
     "Produced by",
@@ -110,6 +113,15 @@ pub(crate) fn time_tag_secs(line: &str) -> Option<f64> {
     }
 }
 
+pub fn format_timestamp(ms: i64) -> String {
+    let cs = (ms.max(0) + 5) / 10;
+    let hundredths = cs % 100;
+    let total_secs = cs / 100;
+    let secs = total_secs % 60;
+    let mins = total_secs / 60;
+    format!("{mins:02}:{secs:02}.{hundredths:02}")
+}
+
 pub(crate) fn is_blank_timed_line(line: &str) -> bool {
     matches!(
         parse_line(line),
@@ -151,7 +163,7 @@ fn keep_line(line: &str, first_time_tag_seen: &mut bool) -> bool {
 
 fn is_title_header(text: &str) -> bool {
     let plain = strip_word_tags(text);
-    plain.contains(" - ") && plain.chars().any(|c| c.is_alphabetic())
+    (plain.contains(" - ") || plain.contains(" — ")) && plain.chars().any(char::is_alphabetic)
 }
 
 fn is_droppable_metadata(line: &str) -> bool {
@@ -233,10 +245,19 @@ fn parse_line(line: &str) -> Option<(Option<f64>, &str)> {
 
 #[cfg(test)]
 mod tests {
+    use super::format_timestamp;
     use super::is_instrumental;
     use super::is_synced;
     use super::sanitize;
     use super::strip_word_tags;
+
+    #[test]
+    fn test_format_timestamp_rounds_to_centiseconds() {
+        assert_eq!(format_timestamp(0), "00:00.00");
+        assert_eq!(format_timestamp(736), "00:00.74");
+        assert_eq!(format_timestamp(65_000), "01:05.00");
+        assert_eq!(format_timestamp(-5), "00:00.00");
+    }
 
     mod strip_word_tags_tests {
         use super::strip_word_tags;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,6 +1,7 @@
 use regex::Regex;
 
 pub mod censor;
+pub mod elrc;
 pub mod lrc;
 pub mod lyricsfile;
 pub mod ttml;

--- a/src/providers/kugou/krc.rs
+++ b/src/providers/kugou/krc.rs
@@ -1,3 +1,4 @@
+use crate::format::elrc;
 use flate2::read::ZlibDecoder;
 use regex::Regex;
 use std::io::Read;
@@ -45,22 +46,21 @@ fn convert(krc: &str) -> String {
             continue;
         };
 
-        let start: u64 = caps[1].parse().unwrap_or(0);
-        let body = &caps[2];
+        let start: i64 = caps[1].parse().unwrap_or(0);
+        let words: Vec<elrc::Word> = word_re
+            .captures_iter(&caps[2])
+            .map(|word| {
+                let offset: i64 = word[1].parse().unwrap_or(0);
+                let duration: i64 = word[2].parse().unwrap_or(0);
+                elrc::Word {
+                    text: word[3].to_string(),
+                    start_ms: start + offset,
+                    end_ms: start + offset + duration,
+                }
+            })
+            .collect();
 
-        let mut rendered = format!("[{}]", format_timestamp(start));
-        let mut last_word_end: Option<u64> = None;
-
-        for word in word_re.captures_iter(body) {
-            let offset: u64 = word[1].parse().unwrap_or(0);
-            let duration: u64 = word[2].parse().unwrap_or(0);
-            let text = &word[3];
-            rendered.push_str(&format!("<{}>{}", format_timestamp(start + offset), text));
-            last_word_end = Some(offset + duration);
-        }
-
-        if let Some(end) = last_word_end {
-            rendered.push_str(&format!("<{}>", format_timestamp(start + end)));
+        if let Some(rendered) = elrc::render_line(start, &words) {
             out.push(rendered);
         }
     }
@@ -68,26 +68,9 @@ fn convert(krc: &str) -> String {
     out.join("\n")
 }
 
-fn format_timestamp(ms: u64) -> String {
-    let cs = (ms + 5) / 10;
-    let hundredths = cs % 100;
-    let total_secs = cs / 100;
-    let secs = total_secs % 60;
-    let mins = total_secs / 60;
-    format!("{mins:02}:{secs:02}.{hundredths:02}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_format_timestamp() {
-        assert_eq!(format_timestamp(0), "00:00.00");
-        assert_eq!(format_timestamp(736), "00:00.74");
-        assert_eq!(format_timestamp(5890), "00:05.89");
-        assert_eq!(format_timestamp(65_000), "01:05.00");
-    }
 
     #[test]
     fn test_convert_word_timing() {
@@ -111,6 +94,15 @@ mod tests {
     fn test_convert_closes_last_word() {
         let krc = "[0,1000]<0,500,0>hi";
         assert_eq!(convert(krc), "[00:00.00]<00:00.00>hi<00:00.50>");
+    }
+
+    #[test]
+    fn test_convert_parks_a_mid_line_pause_on_the_trailing_space() {
+        let krc = "[129364,6000]<0,464,0>guy <5592,360,0>duh";
+        assert_eq!(
+            convert(krc),
+            "[02:09.36]<02:09.36>guy<02:09.83> <02:14.96>duh<02:15.32>"
+        );
     }
 
     #[test]

--- a/src/providers/lrcmux.rs
+++ b/src/providers/lrcmux.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::{PluginConfig, ProviderParams},
     ext::TrackInfoExt,
+    format::{elrc, lrc},
     providers::{LyricsProvider, USER_AGENT},
     types::{Lyrics, LyricsKind},
 };
@@ -145,47 +146,26 @@ impl LyricsProvider for LrcMux {
     }
 }
 
-/// Appends whitespace-only tokens to the word before them, dropping their own
-/// timestamp so the next word's start closes the merged one.
-///
-/// Responses from Musixmatch contain whitespaces as standalone words, and those
-/// separators hold most of the duration, so it looks like words are instantly
-/// highlighted in clients like Feishin. Ideally this should be fixed upstream,
-/// but this implementation should still work fine even if it gets fixed.
-fn merge_separators(words: &[Word]) -> Vec<Word> {
-    let mut out: Vec<Word> = Vec::with_capacity(words.len());
-    for w in words {
-        if w.text.trim().is_empty()
-            && let Some(prev) = out.last_mut()
-        {
-            prev.text.push_str(&w.text);
-            prev.end = w.end.or(prev.end);
-            continue;
-        }
-        out.push(Word {
+fn timed_words(line: &Line, words: &[Word]) -> Vec<elrc::Word> {
+    words
+        .iter()
+        .enumerate()
+        .map(|(i, w)| elrc::Word {
             text: w.text.clone(),
-            start: w.start,
-            end: w.end,
-        });
-    }
-    out
+            start_ms: w.start,
+            end_ms: w
+                .end
+                .or_else(|| words.get(i + 1).map(|next| next.start))
+                .or(line.end)
+                .unwrap_or(w.start),
+        })
+        .collect()
 }
 
 fn build_elrc(lines: &[Line]) -> String {
     lines
         .iter()
-        .filter_map(|l| {
-            let start = l.start?;
-            let words = merge_separators(l.words.as_deref()?);
-            let end = words.last()?.end.or(l.end)?;
-
-            let mut buf = format!("[{}]", ms_to_ts(start));
-            for w in &words {
-                buf.push_str(&format!("<{}>{}", ms_to_ts(w.start), w.text));
-            }
-            buf.push_str(&format!("<{}>", ms_to_ts(end)));
-            Some(buf)
-        })
+        .filter_map(|l| elrc::render_line(l.start?, &timed_words(l, l.words.as_deref()?)))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -193,19 +173,9 @@ fn build_elrc(lines: &[Line]) -> String {
 fn build_lrc(lines: &[Line]) -> String {
     lines
         .iter()
-        .filter_map(|l| Some(format!("[{}] {}", ms_to_ts(l.start?), l.text)))
+        .filter_map(|l| Some(format!("[{}] {}", lrc::format_timestamp(l.start?), l.text)))
         .collect::<Vec<_>>()
         .join("\n")
-}
-
-fn ms_to_ts(ms: i64) -> String {
-    let ms = ms.max(0);
-    let total_cs = ms / 10;
-    let cs = total_cs % 100;
-    let total_secs = total_cs / 100;
-    let secs = total_secs % 60;
-    let mins = total_secs / 60;
-    format!("{mins:02}:{secs:02}.{cs:02}")
 }
 
 fn send_request(url: &str) -> Result<HTTPResponse, Error> {
@@ -251,26 +221,6 @@ mod tests {
     }
 
     #[test]
-    fn test_elrc_folds_separator_tokens_into_the_preceding_word() {
-        let lines = vec![Line {
-            text: "Looks like blue".into(),
-            start: Some(42350),
-            end: Some(44081),
-            words: Some(vec![
-                word("Looks", 42350, 42362),
-                word(" ", 42362, 42726),
-                word("like", 42726, 42746),
-                word(" ", 42746, 42969),
-                word("blue", 42969, 42983),
-            ]),
-        }];
-        assert_eq!(
-            build_elrc(&lines),
-            "[00:42.35]<00:42.35>Looks <00:42.72>like <00:42.96>blue<00:42.98>"
-        );
-    }
-
-    #[test]
     fn test_elrc_ends_on_the_last_word_not_on_the_line() {
         let lines = vec![Line {
             text: "Yeah".into(),
@@ -278,7 +228,7 @@ mod tests {
             end: Some(27672),
             words: Some(vec![word("Yeah", 14075, 14252)]),
         }];
-        assert_eq!(build_elrc(&lines), "[00:14.07]<00:14.07>Yeah<00:14.25>");
+        assert_eq!(build_elrc(&lines), "[00:14.08]<00:14.08>Yeah<00:14.25>");
     }
 
     #[test]
@@ -297,14 +247,24 @@ mod tests {
     }
 
     #[test]
-    fn test_elrc_extends_the_last_word_through_a_trailing_separator() {
+    fn test_elrc_falls_back_to_the_next_word_before_the_line_end() {
         let lines = vec![Line {
-            text: "hello".into(),
+            text: "hello world".into(),
             start: Some(1000),
             end: Some(9000),
-            words: Some(vec![word("hello", 1000, 2000), word(" ", 2000, 2500)]),
+            words: Some(vec![
+                Word {
+                    text: "hello ".into(),
+                    start: 1000,
+                    end: None,
+                },
+                word("world", 2000, 3000),
+            ]),
         }];
-        assert_eq!(build_elrc(&lines), "[00:01.00]<00:01.00>hello <00:02.50>");
+        assert_eq!(
+            build_elrc(&lines),
+            "[00:01.00]<00:01.00>hello <00:02.00>world<00:03.00>"
+        );
     }
 
     #[test]

--- a/src/providers/netease/yrc.rs
+++ b/src/providers/netease/yrc.rs
@@ -1,3 +1,4 @@
+use crate::format::elrc;
 use regex::Regex;
 
 /// YRC lines look like:
@@ -15,22 +16,21 @@ pub fn to_enhanced_lrc(yrc: &str) -> String {
             continue;
         };
 
-        let start: u64 = caps[1].parse().unwrap_or(0);
-        let body = &caps[2];
+        let start: i64 = caps[1].parse().unwrap_or(0);
+        let words: Vec<elrc::Word> = word_re
+            .captures_iter(&caps[2])
+            .map(|word| {
+                let word_start: i64 = word[1].parse().unwrap_or(0);
+                let duration: i64 = word[2].parse().unwrap_or(0);
+                elrc::Word {
+                    text: word[3].to_string(),
+                    start_ms: word_start,
+                    end_ms: word_start + duration,
+                }
+            })
+            .collect();
 
-        let mut rendered = format!("[{}]", format_timestamp(start));
-        let mut last_word_end: Option<u64> = None;
-
-        for word in word_re.captures_iter(body) {
-            let word_start: u64 = word[1].parse().unwrap_or(0);
-            let duration: u64 = word[2].parse().unwrap_or(0);
-            let text = &word[3];
-            rendered.push_str(&format!("<{}>{}", format_timestamp(word_start), text));
-            last_word_end = Some(word_start + duration);
-        }
-
-        if let Some(end) = last_word_end {
-            rendered.push_str(&format!("<{}>", format_timestamp(end)));
+        if let Some(rendered) = elrc::render_line(start, &words) {
             out.push(rendered);
         }
     }
@@ -38,25 +38,9 @@ pub fn to_enhanced_lrc(yrc: &str) -> String {
     out.join("\n")
 }
 
-fn format_timestamp(ms: u64) -> String {
-    let cs = (ms + 5) / 10;
-    let hundredths = cs % 100;
-    let total_secs = cs / 100;
-    let secs = total_secs % 60;
-    let mins = total_secs / 60;
-    format!("{mins:02}:{secs:02}.{hundredths:02}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_format_timestamp() {
-        assert_eq!(format_timestamp(0), "00:00.00");
-        assert_eq!(format_timestamp(736), "00:00.74");
-        assert_eq!(format_timestamp(65_000), "01:05.00");
-    }
 
     #[test]
     fn test_convert_word_timing_absolute() {

--- a/src/providers/qqmusic/qrc.rs
+++ b/src/providers/qqmusic/qrc.rs
@@ -7,6 +7,7 @@
 //! where every timestamp is in absolute milliseconds and the timing tuple comes
 //! after the word it belongs to.
 
+use crate::format::{elrc, lrc};
 use flate2::read::ZlibDecoder;
 use regex::Regex;
 use std::io::Read;
@@ -97,20 +98,17 @@ pub fn to_enhanced_lrc(content: &str) -> String {
     let mut out = Vec::new();
 
     for line in parse_lines(content) {
-        let mut rendered = format!("[{}]", format_timestamp(line.start_ms));
-        let mut last_end: Option<u64> = None;
+        let words: Vec<elrc::Word> = line
+            .words
+            .iter()
+            .map(|word| elrc::Word {
+                text: word.text.clone(),
+                start_ms: word.start_ms as i64,
+                end_ms: (word.start_ms + word.duration_ms) as i64,
+            })
+            .collect();
 
-        for word in &line.words {
-            rendered.push_str(&format!(
-                "<{}>{}",
-                format_timestamp(word.start_ms),
-                word.text
-            ));
-            last_end = Some(word.start_ms + word.duration_ms);
-        }
-
-        if let Some(end) = last_end {
-            rendered.push_str(&format!("<{}>", format_timestamp(end)));
+        if let Some(rendered) = elrc::render_line(line.start_ms as i64, &words) {
             out.push(rendered);
         }
     }
@@ -123,7 +121,11 @@ pub fn to_lrc(content: &str) -> String {
 
     for line in parse_lines(content) {
         let text: String = line.words.iter().map(|w| w.text.as_str()).collect();
-        out.push(format!("[{}]{}", format_timestamp(line.start_ms), text));
+        out.push(format!(
+            "[{}]{}",
+            lrc::format_timestamp(line.start_ms as i64),
+            text
+        ));
     }
 
     out.join("\n")
@@ -174,15 +176,6 @@ pub fn extract_lyric_content(xml: &str) -> Option<String> {
 pub fn is_qrc(content: &str) -> bool {
     let re = Regex::new(r"(?m)^\[\d+,\d+\]").unwrap();
     re.is_match(content)
-}
-
-fn format_timestamp(ms: u64) -> String {
-    let cs = (ms + 5) / 10;
-    let hundredths = cs % 100;
-    let total_secs = cs / 100;
-    let secs = total_secs % 60;
-    let mins = total_secs / 60;
-    format!("{mins:02}:{secs:02}.{hundredths:02}")
 }
 
 fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
@@ -529,13 +522,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_timestamp() {
-        assert_eq!(format_timestamp(0), "00:00.00");
-        assert_eq!(format_timestamp(370), "00:00.37");
-        assert_eq!(format_timestamp(65_000), "01:05.00");
-    }
-
-    #[test]
     fn test_to_enhanced_lrc_absolute_timing() {
         let content =
             "[370,2624]Is (370,336)this (706,285)the (991,355)real (1346,904)life(2250,744)";
@@ -600,3 +586,6 @@ mod tests {
         assert_eq!(to_lrc(""), "");
     }
 }
+
+
+


### PR DESCRIPTION
A few improvements to (E)LRC handling:
- Timestamps now carry hours past 99 minutes, expected by Navidrome.
- Long mid-line gaps/whitespaces now carry their own timestamp to accurately represent word endings.
- Long gaps after implausible sort words (some musixmatch tracks are like this) are folded into the word itself so clients can smoothly highlight them.